### PR TITLE
Lazy syzygies for kernel objects

### DIFF
--- a/ModulePresentationsForCAP/PackageInfo.g
+++ b/ModulePresentationsForCAP/PackageInfo.g
@@ -8,7 +8,7 @@ Version := Maximum( [
            ##
            "2015.12.09", # Sepps version
            ##
-           "2016.09.22", # Mohamed's version
+           "2017.03.27", # Mohamed's version
            ##
            ] ),
 
@@ -80,7 +80,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.6",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ],
-                           [ "MatricesForHomalg", ">=0" ],
+                           [ "MatricesForHomalg", ">=2017.03.27" ],
                            [ "CAP", ">=0" ],
                            [ "ComplexesAndFilteredObjectsForCAP", ">=0" ],
                            [ "GeneralizedMorphismsForCAP", ">=0" ],

--- a/ModulePresentationsForCAP/gap/ModulePresentationMorphism.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationMorphism.gi
@@ -61,13 +61,13 @@ InstallMethod( PresentationMorphism,
     
     if left then
       
-      if NrRows( matrix ) <> NrColumns( UnderlyingMatrix( source ) ) then
+      if NrRows( matrix ) <> source!.nr_generators then
           
           Error( "the number of rows of the given matrix is incorrect" );
           
       fi;
       
-      if NrColumns( matrix ) <> NrColumns( UnderlyingMatrix( range ) ) then
+      if NrColumns( matrix ) <> range!.nr_generators then
         
         Error( "the number of columns of the given matrix is incorrect" );
         
@@ -75,13 +75,13 @@ InstallMethod( PresentationMorphism,
       
     else
       
-      if NrColumns( matrix ) <> NrRows( UnderlyingMatrix( source ) ) then
+      if NrColumns( matrix ) <> source!.nr_generators then
         
         Error( "the number of columns of the given matrix is incorrect" );
         
       fi;
       
-      if NrRows( matrix ) <> NrRows( UnderlyingMatrix( range ) ) then
+      if NrRows( matrix ) <> range!.nr_generators then
         
         Error( "the number of rows of the given matrix is incorrect" );
         

--- a/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
+++ b/ModulePresentationsForCAP/gap/ModulePresentationsForCAP.gi
@@ -376,7 +376,7 @@ InstallGlobalFunction( ADD_KERNEL_LEFT,
         
         embedding := CertainRows( embedding, NonZeroRows( embedding ) );
         
-        kernel := SyzygiesOfRows( embedding, source_matrix );
+        kernel := LazySyzygiesOfRows( embedding, source_matrix );
         
         kernel := AsLeftPresentation( kernel );
         
@@ -431,7 +431,7 @@ InstallGlobalFunction( ADD_KERNEL_RIGHT,
         
         embedding := CertainColumns( embedding, NonZeroColumns( embedding ) );
         
-        kernel := SyzygiesOfColumns( embedding, source_matrix );
+        kernel := LazySyzygiesOfColumns( embedding, source_matrix );
         
         kernel := AsRightPresentation( kernel );
         


### PR DESCRIPTION
This PR includes a commit which fixes #1 , i.e., includes a fix for commit 84c7ab7 which introduced laziness for kernel objects. However the concept of lazy syzygies is still problematic in MatricesForHomalg, as for any other operation that might produce empty matrices.